### PR TITLE
Don't return an unexported type

### DIFF
--- a/ecs.go
+++ b/ecs.go
@@ -57,13 +57,13 @@ func (tag Tag) Inverse(values ...bool) Tag {
 
 type View struct {
 	tag      Tag
-	entities queryResultCollection
+	entities QueryResultCollection
 	lock     *sync.RWMutex
 }
 
-type queryResultCollection []*QueryResult
+type QueryResultCollection []*QueryResult
 
-func (coll queryResultCollection) Entities() []*Entity {
+func (coll QueryResultCollection) Entities() []*Entity {
 	res := make([]*Entity, len(coll))
 	for i, qr := range coll {
 		res[i] = qr.Entity
@@ -72,7 +72,7 @@ func (coll queryResultCollection) Entities() []*Entity {
 	return res
 }
 
-func (v View) Get() queryResultCollection {
+func (v View) Get() QueryResultCollection {
 	v.lock.RLock()
 	defer v.lock.RUnlock()
 	return v.entities
@@ -137,7 +137,7 @@ func (manager *Manager) CreateView(tagelements ...interface{}) *View {
 	}
 
 	entities := manager.Query(tag)
-	view.entities = make(queryResultCollection, len(entities))
+	view.entities = make(QueryResultCollection, len(entities))
 	manager.lock.Lock()
 	for i, entityresult := range entities {
 		view.entities[i] = entityresult
@@ -399,9 +399,9 @@ func (manager *Manager) fetchComponentsForEntity(entity *Entity, tag Tag) map[*C
 	return componentMap
 }
 
-func (manager *Manager) Query(tag Tag) queryResultCollection {
+func (manager *Manager) Query(tag Tag) QueryResultCollection {
 
-	matches := make(queryResultCollection, 0)
+	matches := make(QueryResultCollection, 0)
 
 	manager.lock.RLock()
 	for _, entity := range manager.entities {

--- a/ecs.go
+++ b/ecs.go
@@ -72,7 +72,7 @@ func (coll QueryResultCollection) Entities() []*Entity {
 	return res
 }
 
-func (v View) Get() QueryResultCollection {
+func (v *View) Get() QueryResultCollection {
 	v.lock.RLock()
 	defer v.lock.RUnlock()
 	return v.entities
@@ -123,7 +123,7 @@ func (component *Component) SetDestructor(destructor func(entity *Entity, data i
 	component.destructor = destructor
 }
 
-func (component Component) GetID() ComponentID {
+func (component *Component) GetID() ComponentID {
 	return component.id
 }
 
@@ -238,7 +238,7 @@ func (manager *Manager) NewComponent() *Component {
 	return component
 }
 
-func (manager Manager) GetEntityByID(id EntityID, tagelements ...interface{}) *QueryResult {
+func (manager *Manager) GetEntityByID(id EntityID, tagelements ...interface{}) *QueryResult {
 
 	manager.lock.RLock()
 	res, ok := manager.entitiesByID[id]


### PR DESCRIPTION
This PR renames `queryResultCollection` to `QueryResultCollection` so that it's exported. This is preventing me to write a wrapper for ecs's types, and is often considered as a bad practice: https://github.com/golang/lint/issues/210